### PR TITLE
MTD-32 untranslated content original

### DIFF
--- a/config/sync/language.content_settings.menu_link_content.pension-benefits-hub.yml
+++ b/config/sync/language.content_settings.menu_link_content.pension-benefits-hub.yml
@@ -10,7 +10,7 @@ third_party_settings:
   content_translation:
     enabled: true
     bundle_settings:
-      untranslatable_fields_hide: '0'
+      untranslatable_fields_hide: '1'
 id: menu_link_content.pension-benefits-hub
 target_entity_type_id: menu_link_content
 target_bundle: pension-benefits-hub

--- a/config/sync/language.content_settings.paragraph.link_teaser.yml
+++ b/config/sync/language.content_settings.paragraph.link_teaser.yml
@@ -10,7 +10,7 @@ third_party_settings:
   content_translation:
     enabled: true
     bundle_settings:
-      untranslatable_fields_hide: '0'
+      untranslatable_fields_hide: '1'
 id: paragraph.link_teaser
 target_entity_type_id: paragraph
 target_bundle: link_teaser

--- a/config/sync/language.content_settings.paragraph.list_of_link_teasers.yml
+++ b/config/sync/language.content_settings.paragraph.list_of_link_teasers.yml
@@ -10,7 +10,7 @@ third_party_settings:
   content_translation:
     enabled: true
     bundle_settings:
-      untranslatable_fields_hide: '0'
+      untranslatable_fields_hide: '1'
 id: paragraph.list_of_link_teasers
 target_entity_type_id: paragraph
 target_bundle: list_of_link_teasers

--- a/config/sync/language.content_settings.paragraph.q_a.yml
+++ b/config/sync/language.content_settings.paragraph.q_a.yml
@@ -10,7 +10,7 @@ third_party_settings:
   content_translation:
     enabled: true
     bundle_settings:
-      untranslatable_fields_hide: '0'
+      untranslatable_fields_hide: '1'
 id: paragraph.q_a
 target_entity_type_id: paragraph
 target_bundle: q_a

--- a/config/sync/language.content_settings.paragraph.q_a_section.yml
+++ b/config/sync/language.content_settings.paragraph.q_a_section.yml
@@ -10,7 +10,7 @@ third_party_settings:
   content_translation:
     enabled: true
     bundle_settings:
-      untranslatable_fields_hide: '0'
+      untranslatable_fields_hide: '1'
 id: paragraph.q_a_section
 target_entity_type_id: paragraph
 target_bundle: q_a_section

--- a/config/sync/language.content_settings.paragraph.wysiwyg.yml
+++ b/config/sync/language.content_settings.paragraph.wysiwyg.yml
@@ -10,7 +10,7 @@ third_party_settings:
   content_translation:
     enabled: true
     bundle_settings:
-      untranslatable_fields_hide: '0'
+      untranslatable_fields_hide: '1'
 id: paragraph.wysiwyg
 target_entity_type_id: paragraph
 target_bundle: wysiwyg


### PR DESCRIPTION
This resolves the bug (misconfiguration) that presents a translation editor with fields that can not be edited which creates the blocking error.  This resolves that.